### PR TITLE
fix effects module declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "build:aos-extension": "rm -rf dist && ng build aos-extension && cpr projects/aos-extension/assets dist/aos-extension/assets",
+    "build:aos-extension": "rm -rf dist && ng build aos-extension && cp projects/aos-extension/ngi.json dist/aos-extension && cpr projects/aos-extension/assets dist/aos-extension/assets",
     "pack:aos-extension": "cd dist/aos-extension && npm pack",
     "package:aos-extension": "npm run build:aos-extension && npm run pack:aos-extension"
   },

--- a/projects/aos-extension/ngi.json
+++ b/projects/aos-extension/ngi.json
@@ -1,0 +1,14 @@
+{
+  "assets": [
+    {
+      "from": "assets/aos.plugin.json",
+      "to": "plugins"
+    }
+  ],
+  "modules": [
+    {
+      "name": "AosExtensionModule",
+      "namespace": "aos-extension"
+    }
+  ]
+}

--- a/projects/aos-extension/src/lib/aos-extension.module.ts
+++ b/projects/aos-extension/src/lib/aos-extension.module.ts
@@ -8,7 +8,7 @@ import { AosEffects } from './effects/aos.effects';
 
 @NgModule({
   imports: [
-    EffectsModule.forRoot([AosEffects])
+    EffectsModule.forFeature([AosEffects])
   ],
   declarations: [AosExtensionComponent],
   exports: [AosExtensionComponent],


### PR DESCRIPTION
Fix the issue with core effects not working after import.
Provide settings for `ngi` tool (to greatly simplify install experience)

Final experience with the [ngi](https://www.npmjs.com/package/@ngstack/install) tool can be as following:

1. Install the tarball

```sh
ngi <path-to>/aos-extension-0.0.1.tgz aos-extension
```

2 update the `app.extensions.json` to add `aos.plugin.json` reference
3. Run the app